### PR TITLE
🦁 ADD - development pvc to each user namespace 🦁

### DIFF
--- a/manifests/object-detection-workshop/od-workshop-chart/templates/user-projects.yaml
+++ b/manifests/object-detection-workshop/od-workshop-chart/templates/user-projects.yaml
@@ -76,6 +76,26 @@ spec:
       storage: 10Gi
   volumeMode: Filesystem
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    openshift.io/description: ''
+    openshift.io/display-name: development
+  name: development
+  namespace: {{ printf "user%d" $i }}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeMode: Filesystem
+---
 apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
 kind: DataSciencePipelinesApplication
 metadata:


### PR DESCRIPTION
For `development` PVC is to be provisioned for each user to complete the below step:

> Under Cluster storage select Use existing persistent storage and select development, a volume that was provisioned ahead of the workshop for your convenience.