### PR TITLE
Update path for gitInitImage in model-ci-cos.yaml

### DIFF
--- a/manifests/tekton/model-ci-cos.yaml
+++ b/manifests/tekton/model-ci-cos.yaml
@@ -85,7 +85,7 @@ spec:
       description: Log the commands that are executed during `git-clone`'s operation.
       name: verbose
       type: string
-    - default: 'gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2'
+    - default: 'ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2'
       description: The image providing the git-init binary that this Task runs.
       name: gitInitImage
       type: string


### PR DESCRIPTION
Tekton has fully migrated to GitHub Container Registry (GHCR).The image we need now lives at: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2